### PR TITLE
Batching edits

### DIFF
--- a/src/app/codemirror/mode/docCache.ts
+++ b/src/app/codemirror/mode/docCache.ts
@@ -4,6 +4,7 @@
 import {TypedEvent} from "../../../common/events";
 import * as CodeMirror from "codemirror";
 import {cast, server} from "../../../socket/socketClient";
+import * as editBatcher from "./editBatcher";
 import * as utils from "../../../common/utils";
 import * as classifierCache from "./classifierCache";
 import {RefactoringsByFilePath, Refactoring} from "../../../common/types";
@@ -169,8 +170,7 @@ function getOrCreateDoc(filePath: string): Promise<DocPromiseResult> {
                 };
 
                 // Send the edit
-                // TODO: batch by trottling (by filepath) and send these to the server
-                server.editFile({ filePath: filePath, edits: [codeEdit] });
+                editBatcher.addToQueue(filePath, codeEdit);
 
                 // Keep the ouput status cache informed
                 state.ifJSStatusWasCurrentThenMoveToOutOfDate({inputFilePath: filePath});

--- a/src/app/codemirror/mode/docCache.ts
+++ b/src/app/codemirror/mode/docCache.ts
@@ -169,6 +169,7 @@ function getOrCreateDoc(filePath: string): Promise<DocPromiseResult> {
                 };
 
                 // Send the edit
+                // TODO: batch by trottling (by filepath) and send these to the server
                 server.editFile({ filePath: filePath, edits: [codeEdit] });
 
                 // Keep the ouput status cache informed

--- a/src/app/codemirror/mode/editBatcher.ts
+++ b/src/app/codemirror/mode/editBatcher.ts
@@ -3,6 +3,7 @@
  */
 /** imports */
 import {cast, server} from "../../../socket/socketClient";
+import * as utils from "../../../common/utils";
 
 
 /**
@@ -12,6 +13,26 @@ const pendingQueue: { [filePath: string]: CodeEdit[] } = Object.create(null);
 
 
 export function addToQueue(filePath: string, edit: CodeEdit) {
-    // TODO: batch by trottling (by filepath) and send these to the server
-    server.editFile({ filePath: filePath, edits: [edit] });
+    // Batch by by filePath and setup for sending later
+    if (!pendingQueue[filePath]) pendingQueue[filePath] = [];
+    pendingQueue[filePath].push(edit);
+
+    // Mark for sending
+    delayedFlushQueue();
 }
+
+export function flushQueue() {
+    Object.keys(pendingQueue).forEach(filePath => {
+        const edits = pendingQueue[filePath];
+        server.editFile({ filePath: filePath, edits });
+
+        /** Clear for future */
+        delete pendingQueue[filePath];
+    });
+}
+
+/**
+ * Note: this delay must be less than any other delays
+ * (e.g. autocomplete throttling should be more than this).
+ */
+export const delayedFlushQueue = utils.throttle(flushQueue, 200);

--- a/src/app/codemirror/mode/editBatcher.ts
+++ b/src/app/codemirror/mode/editBatcher.ts
@@ -1,0 +1,17 @@
+/**
+ * When sending edits to the server we *batch them by filePath*.
+ */
+/** imports */
+import {cast, server} from "../../../socket/socketClient";
+
+
+/**
+ * The queue of edits by filePath that we still have to send
+ */
+const pendingQueue: { [filePath: string]: CodeEdit[] } = Object.create(null);
+
+
+export function addToQueue(filePath: string, edit: CodeEdit) {
+    // TODO: batch by trottling (by filepath) and send these to the server
+    server.editFile({ filePath: filePath, edits: [edit] });
+}

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
         server.build({});
     });
     /** Consolidate the file edit stuff into a single command */
-    cast.didEdit.on((e)=>{commands.fileContentsChanged.emit({filePath:e.filePath})});
+    cast.didEdits.on((e)=>{commands.fileContentsChanged.emit({filePath:e.filePath})});
     cast.savedFileChangedOnDisk.on((e)=>{commands.fileContentsChanged.emit({filePath:e.filePath})});
     commands.toggleDoctor.on(()=>{
         if (!state.inActiveProjectFilePath(tabState.getSelectedFilePath())){

--- a/src/server/disk/activeProjectConfig.ts
+++ b/src/server/disk/activeProjectConfig.ts
@@ -256,5 +256,5 @@ function checkProjectFileChanges(evt: { filePath: string }) {
     }
 }
 const checkProjectFileChangesDebounced = utils.debounce(checkProjectFileChanges, 1000);
-fmc.didEdit.on(checkProjectFileChangesDebounced);
+fmc.didEdits.on(checkProjectFileChangesDebounced);
 fmc.savedFileChangedOnDisk.on(checkProjectFileChangesDebounced);

--- a/src/server/disk/fileModelCache.ts
+++ b/src/server/disk/fileModelCache.ts
@@ -7,7 +7,7 @@ import * as fsu from "../utils/fsu";
 import * as types from "../../common/types";
 
 export var savedFileChangedOnDisk = new TypedEvent<{ filePath: string; contents: string }>();
-export var didEdit = new TypedEvent<{ filePath: string; edit: CodeEdit }>();
+export var didEdits = new TypedEvent<{ filePath: string; edits: CodeEdit[] }>();
 export var didStatusChange = new TypedEvent<types.FileStatus>();
 export var editorOptionsChanged = new TypedEvent<{filePath: string; editorOptions: types.EditorOptions}>();
 export var didOpenFile = new TypedEvent<{filePath: string, contents: string}>();
@@ -37,8 +37,8 @@ export function getOrCreateOpenFile(filePath: string, autoCreate = false) {
         file.onSavedFileChangedOnDisk.on((evt) => {
             savedFileChangedOnDisk.emit({ filePath, contents: evt.contents });
         });
-        file.didEdit.on((evt) => {
-            didEdit.emit({ filePath, edit: evt.codeEdit });
+        file.didEdits.on((evt) => {
+            didEdits.emit({ filePath, edits: evt.codeEdits });
         });
         file.didStatusChange.on((evt) => {
             didStatusChange.emit({ filePath, saved: evt.saved, eol: evt.eol });

--- a/src/server/lang/config/configService.ts
+++ b/src/server/lang/config/configService.ts
@@ -55,15 +55,17 @@ fmc.didOpenFile.on(e => {
         project.languageServiceHost.addScript(e.filePath, prelude + e.contents);
     }
 });
-fmc.didEdit.on(e => {
+fmc.didEdits.on(e => {
     const config = project.isSupportedFile(e.filePath);
     if (config) {
         const prelude = config.prelude;
-        const {filePath, edit: codeEdit} = e;
-        const from = { line: codeEdit.from.line + 1, ch: codeEdit.from.ch };
-        const to = { line: codeEdit.to.line + 1, ch: codeEdit.to.ch };
-        project.languageServiceHost.applyCodeEdit(filePath, from, to, codeEdit.newText);
-        debouncedErrorUpdate(filePath);
+        const {filePath, edits: codeEdits} = e;
+        codeEdits.forEach(codeEdit => {
+            const from = { line: codeEdit.from.line + 1, ch: codeEdit.from.ch };
+            const to = { line: codeEdit.to.line + 1, ch: codeEdit.to.ch };
+            project.languageServiceHost.applyCodeEdit(filePath, from, to, codeEdit.newText);
+            debouncedErrorUpdate(filePath);
+        });
     }
 });
 fmc.savedFileChangedOnDisk.on(e => {

--- a/src/server/workers/lang/activeProject.ts
+++ b/src/server/workers/lang/activeProject.ts
@@ -55,20 +55,22 @@ function sync() {
 /**
  * File changing on disk
  */
-export function fileEdited(evt: { filePath: string, edit: CodeEdit }) {
+export function fileEdited(evt: { filePath: string, edits: CodeEdit[] }) {
     let proj = GetProject.ifCurrent(evt.filePath)
     if (proj) {
-        proj.languageServiceHost.applyCodeEdit(evt.filePath, evt.edit.from, evt.edit.to, evt.edit.newText);
-        // For debugging
-        // console.log(proj.languageService.getSourceFile(evt.filePath).text);
+        evt.edits.forEach(edit=>{
+            proj.languageServiceHost.applyCodeEdit(evt.filePath, edit.from, edit.to, edit.newText);
+            // For debugging
+            // console.log(proj.languageService.getSourceFile(evt.filePath).text);
 
-        // update errors for this file if its *heuristically* small
-        if (evt.edit.from.line < 1000) {
-            refreshFileDiagnostics(evt.filePath);
-        }
+            // update errors for this file if its *heuristically* small
+            if (edit.from.line < 1000) {
+                refreshFileDiagnostics(evt.filePath);
+            }
 
-        // After a while update all project diagnostics as well
-        refreshAllProjectDiagnosticsDebounced();
+            // After a while update all project diagnostics as well
+            refreshAllProjectDiagnosticsDebounced();
+        });
     }
 }
 export function fileChangedOnDisk(evt: { filePath: string; contents: string }) {

--- a/src/server/workers/lang/projectServiceContract.ts
+++ b/src/server/workers/lang/projectServiceContract.ts
@@ -15,7 +15,7 @@ import * as socketContract from "../../../socket/socketContract";
 export var worker = {
     echo: {} as sw.QRFunction<{ data: string }, { data: string }>,
 
-    fileEdited: {} as sw.QRFunction<{ filePath: string; edit: CodeEdit }, {}>,
+    fileEdited: {} as sw.QRFunction<{ filePath: string; edits: CodeEdit[] }, {}>,
     fileChangedOnDisk: {} as sw.QRFunction<{ filePath: string; contents: string }, {}>,
     fileSaved: {} as sw.QRFunction<{ filePath: string }, {}>,
 

--- a/src/server/workers/lang/projectServiceMaster.ts
+++ b/src/server/workers/lang/projectServiceMaster.ts
@@ -69,7 +69,7 @@ export function start() {
         worker.setActiveProjectConfigDetails({projectData});
     });
     fileListingMaster.fileListingDelta.on((delta)=>activeProjectConfig.fileListingDelta(delta));
-    fmc.didEdit.on((edit)=>worker.fileEdited(edit));
+    fmc.didEdits.on((edits)=>worker.fileEdited(edits));
     fmc.savedFileChangedOnDisk.on((update)=>worker.fileChangedOnDisk(update));
     fmc.didStatusChange.on((update) => update.saved && worker.fileSaved({ filePath: update.filePath }));
 }

--- a/src/socket/socketContract.ts
+++ b/src/socket/socketContract.ts
@@ -20,7 +20,7 @@ export var server = {
      */
     openFile: {} as QRFunction<{ filePath: string }, { contents: string, saved: boolean, editorOptions: types.EditorOptions }>,
     closeFile: {} as QRFunction<{ filePath: string }, {}>,
-    editFile: {} as QRFunction<{ filePath: string, edit: CodeEdit }, { saved: boolean }>,
+    editFile: {} as QRFunction<{ filePath: string, edits: CodeEdit[] }, { saved: boolean }>,
     saveFile: {} as QRFunction<{ filePath: string }, {}>,
     getFileStatus: {} as QRFunction<{ filePath: string }, { saved: boolean }>,
     /** File Tree */
@@ -124,7 +124,7 @@ export var cast = {
     savedFileChangedOnDisk: new TypedEvent<{ filePath: string; contents: string }>(),
 
     /** If a user does a code edit */
-    didEdit: new TypedEvent<{ filePath: string, edit: CodeEdit }>(),
+    didEdits: new TypedEvent<{ filePath: string, edits: CodeEdit[] }>(),
 
     /** If any of the file status changes */
     didStatusChange: new TypedEvent<{ filePath: string, saved: boolean, eol: string}>(),

--- a/src/socket/socketServer.ts
+++ b/src/socket/socketServer.ts
@@ -56,7 +56,7 @@ namespace Server {
     }
     export var editFile: typeof contract.server.editFile = (data) => {
         let file = fmc.getOrCreateOpenFile(data.filePath);
-        let {saved} = file.edit(data.edit);
+        let {saved} = file.edits(data.edits);
         // console.log('-------------------------');
         // console.log(file.getContents());
         return resolve({ saved });
@@ -248,7 +248,7 @@ export function register(app: http.Server | https.Server) {
 
     /** File model */
     fmc.savedFileChangedOnDisk.pipe(cast.savedFileChangedOnDisk);
-    fmc.didEdit.pipe(cast.didEdit);
+    fmc.didEdits.pipe(cast.didEdits);
     fmc.didStatusChange.pipe(cast.didStatusChange);
     fmc.editorOptionsChanged.pipe(cast.editorOptionsChanged);
 


### PR DESCRIPTION
Open a big file that is poorly formatted and *format* it. We suddenly get 100+ edits being sent to the backend one by one. This can be slow. Now we batch edits made in quick succession. This was (is) a long term issue with atom-typescript :rose: