### PR TITLE
Remove glob-expand

### DIFF
--- a/docs/config/tsconfig.md
+++ b/docs/config/tsconfig.md
@@ -12,8 +12,8 @@ We support autocomplete for many of the TSConfig options:
 The following are the key properties of `tsconfig.json`:
 
 * [`compilerOptions`](#compileroptions)
-* [`filesGlob`](#filesglob)
 * [`files`](#files)
+* [`include`](#include)
 * [`exclude`](#exclude)
 * [`compileOnSave`](#compileonsave)
 * [`formatCodeOptions`](#formatcodeoptions)
@@ -31,44 +31,10 @@ The key compiler options. e.g:
 ```
 The docs for these compiler options [exist here](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Compiler%20Options.md).
 
-### filesGlob
-
-We support [node style globs](npmjs.com/package/glob). e.g.
-
-```json
-"filesGlob": [
-  "**/*.ts",
-  "**/*.tsx",
-  "!node_modules/**"
-]
-```
-
-Note: The proper way to exclude a directory in node's `glob` module is `!somedirectory/**`. E.g. `!node_modules/**`. Please **don't add** a trailing `*` (e.g. `!node_modules/**/*.ts`) as that will force us to list the directory which can be slow.
-
 ### files
-
-You can specify individual files instead of using a glob.
-
-```json
-"files": [
-  "core.ts",
-  "sys.ts",
-  "types.ts"
-]
-```
-
-> 🔴: This option is ignored if you use `filesGlob`. Use either `files` or `filesGlob`
-
+### include
 ### exclude
-
-You can specify exclude directories using `exclude` property. E.g.
-
-```json
-"exclude": [
-  "node_modules",
-  "wwwroot"
-]
-```
+Please see the docs here : https://basarat.gitbooks.io/typescript/content/docs/project/files.html
 
 ### compileOnSave
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "express": "4.13.0",
     "fuzzaldrin": "^2.1.0",
     "glob": "^7.0.5",
-    "glob-expand": "^0.1.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "monaco": "1.201608100247.0",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -309,7 +309,6 @@ export interface TsconfigJsonParsed {
     compilerOptions: ts.CompilerOptions;
     files: string[];
     typings: string[]; // These are considered externs for .d.ts. Note : duplicated in files
-    filesGlob?: string[];
     /**
      * This is cached in the parsed result as the final thing we are expanding
      * Takes into account `filesGlob` + `exclude` + `outDir` + anything else

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -309,12 +309,6 @@ export interface TsconfigJsonParsed {
     compilerOptions: ts.CompilerOptions;
     files: string[];
     typings: string[]; // These are considered externs for .d.ts. Note : duplicated in files
-    /**
-     * This is cached in the parsed result as the final thing we are expanding
-     * Takes into account `filesGlob` + `exclude` + `outDir` + anything else
-     * Helps us know if a file delta is significant for this project later
-     */
-    toExpand?: string[];
     formatCodeOptions: ts.FormatCodeOptions;
     compileOnSave: boolean;
     buildOnSave: boolean;

--- a/src/server/workers/lang/core/tsconfig.ts
+++ b/src/server/workers/lang/core/tsconfig.ts
@@ -254,7 +254,10 @@ export function getProjectSync(pathOrSrcFile: string): GetProjectSyncResponse {
         return { error: bland };
     }
 
-    /** Finally expand whatever needs expanding */
+    /**
+     * Finally expand whatever needs expanding
+     * See : https://github.com/TypeStrong/tsconfig/issues/19
+     */
     try {
         const tsResult = ts.parseJsonConfigFileContent(projectSpec, ts.sys, path.dirname(projectFile), null, projectFile);
         // console.log(tsResult); // DEBUG

--- a/src/server/workers/lang/core/tsconfig.ts
+++ b/src/server/workers/lang/core/tsconfig.ts
@@ -102,7 +102,6 @@ interface TypeScriptProjectRawSpecification {
     exclude?: string[];                                 // optional: An array of 'glob / minimatch / RegExp' patterns to specify directories / files to exclude
     include?: string[];                                 // optional: An array of 'glob / minimatch / RegExp' patterns to specify directories / files to include
     files?: string[];                                   // optional: paths to files
-    filesGlob?: string[];                               // optional: An array of 'glob / minimatch / RegExp' patterns to specify source files
     formatCodeOptions?: formatting.FormatCodeOptions;   // optional: formatting options
     compileOnSave?: boolean;                            // optional: compile on save. Ignored to build tools. Used by IDEs
     buildOnSave?: boolean;
@@ -260,20 +259,14 @@ export function getProjectSync(pathOrSrcFile: string): GetProjectSyncResponse {
     var cwdPath = path.relative(process.cwd(), path.dirname(projectFile));
     let toExpand = [];
     /** Determine the glob to expand (if any) */
-    if (!projectSpec.files && !projectSpec.filesGlob && !projectSpec.include && projectSpec.compilerOptions.allowJs) {
+    if (!projectSpec.files && !projectSpec.include && projectSpec.compilerOptions.allowJs) {
         toExpand = invisibleFilesGlobWithJS;
     }
-    else if (!projectSpec.files && !projectSpec.filesGlob && !projectSpec.include) {
+    else if (!projectSpec.files && !projectSpec.include) {
         toExpand = invisibleFilesGlob;
     }
-    else if (projectSpec.filesGlob || projectSpec.include) {
-        // If there is a files glob we will use that first
-        if (projectSpec.filesGlob) {
-            toExpand = projectSpec.filesGlob;
-        }
-        else {
-            toExpand = [];
-        }
+    else if (projectSpec.include) {
+        toExpand = [];
         // Now include the `include` if any
         if (projectSpec.include) {
             toExpand = toExpand.concat(projectSpec.include.map(x => `./${x}`));
@@ -329,7 +322,6 @@ export function getProjectSync(pathOrSrcFile: string): GetProjectSyncResponse {
     var project: TsconfigJsonParsed = {
         compilerOptions: {},
         files: projectSpec.files.map(x => path.resolve(projectFileDirectory, x)),
-        filesGlob: projectSpec.filesGlob,
         toExpand: toExpand,
         formatCodeOptions: formatting.makeFormatCodeOptions(projectSpec.formatCodeOptions),
         compileOnSave: projectSpec.compileOnSave == undefined ? true : projectSpec.compileOnSave,

--- a/src/server/workers/lang/core/tsconfig.ts
+++ b/src/server/workers/lang/core/tsconfig.ts
@@ -114,8 +114,6 @@ export var errors = {
     GET_PROJECT_INVALID_PATH: 'The path used to query for tsconfig.json does not exist',
     GET_PROJECT_NO_PROJECT_FOUND: 'No Project Found',
     GET_PROJECT_FAILED_TO_OPEN_PROJECT_FILE: 'Failed to fs.readFileSync the project file',
-    GET_PROJECT_JSON_PARSE_FAILED: 'Failed to JSON.parse the project file',
-    GET_PROJECT_GLOB_EXPAND_FAILED: 'Failed to expand filesGlob in the project file',
     GET_PROJECT_PROJECT_FILE_INVALID_OPTIONS: 'Project file contains invalid options',
 
     CREATE_FILE_MUST_EXIST: 'The Typescript file must exist on disk in order to create a project',
@@ -127,7 +125,6 @@ export interface ProjectFileErrorDetails {
 }
 
 import path = require('path');
-import expand = require('glob-expand');
 import os = require('os');
 import formatting = require('./formatCodeOptions');
 

--- a/src/server/workers/lang/core/tsconfig.ts
+++ b/src/server/workers/lang/core/tsconfig.ts
@@ -99,8 +99,8 @@ interface CompilerOptions {
  */
 interface TypeScriptProjectRawSpecification {
     compilerOptions?: CompilerOptions;
-    exclude?: string[];                                 // optional: An array of 'glob / minimatch / RegExp' patterns to specify directories / files to exclude
-    include?: string[];                                 // optional: An array of 'glob / minimatch / RegExp' patterns to specify directories / files to include
+    exclude?: string[];                                 // optional: An array of 'glob' patterns to specify directories / files to exclude
+    include?: string[];                                 // optional: An array of 'glob' patterns to specify directories / files to include
     files?: string[];                                   // optional: paths to files
     formatCodeOptions?: formatting.FormatCodeOptions;   // optional: formatting options
     compileOnSave?: boolean;                            // optional: compile on save. Ignored to build tools. Used by IDEs

--- a/src/typings/glob-expand.d.ts
+++ b/src/typings/glob-expand.d.ts
@@ -1,4 +1,0 @@
-declare module "glob-expand" {
-    var foo;
-    export = foo;
-}

--- a/src/typings/multimatch.d.ts
+++ b/src/typings/multimatch.d.ts
@@ -1,6 +1,0 @@
-// https://github.com/sindresorhus/multimatch
-declare module 'multimatch' {
-    /** Returns the paths that match the patterns */
-    function multimatch(paths:string[],patterns:string[]): string[];
-    export = multimatch;
-}

--- a/tests/cycles/tsconfig.json
+++ b/tests/cycles/tsconfig.json
@@ -14,11 +14,6 @@
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },
-    "filesGlob": [
-        "**/*.ts",
-        "**/*.tsx",
-        "!node_modules/**"
-    ],
     "compileOnSave": true,
     "buildOnSave": false,
     "files": [

--- a/tests/error/tsconfigInvalidJson/tsconfig.json
+++ b/tests/error/tsconfigInvalidJson/tsconfig.json
@@ -14,11 +14,6 @@
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },
-    "filesGlob": [
-        "./**/*.ts",
-        "./**/*.tsx",
-        "!./node_modules/**/*"
-    ],
     "files": [
         "./test.ts"
     ]

--- a/tests/success/allowJs/tsconfig.json
+++ b/tests/success/allowJs/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "outDir": "./js"
   },
-  "filesGlob": [
-    "./src/**"
+  "include": [
+    "./src/**/*"
   ]
 }

--- a/tests/success/simple/tsconfig.json
+++ b/tests/success/simple/tsconfig.json
@@ -14,10 +14,8 @@
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },
-    "filesGlob": [
-        "**/*.ts",
-        "**/*.tsx",
-        "!node_modules/**"
+    "include": [
+        "**/*"
     ],
     "exclude": [],
     "atom": {


### PR DESCRIPTION
Its really old. Also typescript has native glob support now so we should be forward facing. 

* `tsconfig` has already removed support for `filesGlob`:  https://github.com/TypeStrong/tsconfig/releases/tag/v4.0.0

* glob-expand depends on really old `glob` and `lodash` and is a problem.

# Test Plan 

* [x] add a new .ts file or a .js file and we should resync
* [x] include should pickup files 
* [x] exclude should ignore new files that don't match
* [x] test with incremental expansion disabled to make sure that isn't fixing it. Log filenames at all points
* [ ] release as a major version upgrade